### PR TITLE
 fix: mobile responsive pass + footer/layout cleanup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,25 @@
   "permissions": {
     "allow": [
       "Bash(npx tsc --noEmit)",
-      "Bash(npm test)"
+      "Bash(npm test)",
+      "Bash(npm run dev)",
+      "Bash(npm run build)",
+      "Bash(npm run start)",
+      "Bash(npm run lint)",
+      "Bash(npm run cron:renew)",
+      "Bash(npx next lint)",
+      "Bash(npx prisma generate)",
+      "Bash(npx prisma studio)",
+      "Read(/Users/morthalion/.claude/projects/**)",
+      "mcp__plugin_playwright_playwright__browser_navigate",
+      "mcp__plugin_playwright_playwright__browser_resize",
+      "mcp__plugin_playwright_playwright__browser_take_screenshot",
+      "mcp__plugin_playwright_playwright__browser_snapshot",
+      "mcp__plugin_playwright_playwright__browser_evaluate",
+      "mcp__plugin_playwright_playwright__browser_click",
+      "mcp__plugin_playwright_playwright__browser_wait_for",
+      "mcp__plugin_playwright_playwright__browser_console_messages",
+      "mcp__plugin_playwright_playwright__browser_navigate_back"
     ]
   }
 }

--- a/docs/superpowers/plans/2026-07-02-mobile-responsive-pass.md
+++ b/docs/superpowers/plans/2026-07-02-mobile-responsive-pass.md
@@ -1,0 +1,400 @@
+# Mobile Responsive Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every page/screen of "The Veil" usable at 320–480px, fixing the concentrated breakage (reused `.mystic-btn`, missing overflow guard, inconsistent breakpoints) without disturbing the desktop layout or intro animations.
+
+**Architecture:** Introduce a shared Sass breakpoint map + `respond-below`/`respond-above` mixins as the single source of truth for breakpoint values. Keep each file's existing mobile-first vs desktop-first direction; only swap raw px → named tokens and add the missing mobile rules. Fix the one un-responsive primitive (`.mystic-btn`) first — it resolves the 3 worst surfaces at once.
+
+**Tech Stack:** SCSS (Dart Sass, legacy `@import` in `style.scss`), Next.js 14 App Router, React 18. Verification via dev server on :3001 + Playwright MCP at a 375px viewport.
+
+## Global Constraints
+
+- No new colors — existing CSS custom properties only (`_variables.scss`).
+- Never use `opacity` to vary text color — use `--text-soft` (0.9) / `--text-faint` (0.7).
+- No wildcard (`*`) selectors for animation/skip-intro overrides — list specific elements.
+- No layout (flex/width) baked into reusable components — parent owns layout.
+- Never hardcode color values — use `var(--xxx)`. For opacity variants use `rgba(250, 225, 163, 0.XX)`.
+- **NEVER run git add/commit/stage** — the user commits themselves. No task includes a commit step.
+- Always use Opus for any subagent.
+- Dev server runs on **:3001**, not 3000.
+- `style.css` / `style.css.map` are compiled artifacts — never edit; only edit `.scss` sources.
+
+**Verification primitive (used by most tasks):** with the dev server on :3001, drive Playwright MCP: `browser_resize` to 375×812, `browser_navigate` to the page, `browser_take_screenshot`, then `browser_evaluate` `() => document.documentElement.scrollWidth <= window.innerWidth` — expect `true` (no horizontal scroll). Between tasks the user commits; do not commit for them.
+
+---
+
+### Task 1: Breakpoint infrastructure
+
+**Files:**
+- Modify: `src/assets/scss/_mixins.scss` (append at end)
+
+**Interfaces:**
+- Produces: `$breakpoints` map (`sm: 37.5em`, `md: 48em`, `lg: 56.25em` = 600/768/900px); mixins `respond-below($bp)` and `respond-above($bp)`. Later tasks call `@include respond-below(sm) { ... }` etc. `_mixins.scss` is imported by `style.scss` before all block partials, so the mixins are globally available.
+
+- [ ] **Step 1: Add the map + mixins to `_mixins.scss`**
+
+Append:
+
+```scss
+// ── Responsive breakpoints ──
+// Single source of truth. Files keep their existing mobile-first (respond-above)
+// or desktop-first (respond-below) direction; only the VALUE is centralized.
+$breakpoints: (
+  sm: 37.5em,   // 600px
+  md: 48em,     // 768px
+  lg: 56.25em,  // 900px
+);
+
+@mixin respond-below($bp) {
+  @media (max-width: map-get($breakpoints, $bp)) {
+    @content;
+  }
+}
+
+@mixin respond-above($bp) {
+  @media (min-width: map-get($breakpoints, $bp)) {
+    @content;
+  }
+}
+```
+
+- [ ] **Step 2: Add a temporary probe to prove the mixin compiles**
+
+Temporarily append to `_mixins.scss` a throwaway rule, then remove after build:
+
+```scss
+.__bp_probe { @include respond-below(sm) { color: var(--text-color); } }
+```
+
+- [ ] **Step 3: Build to verify Sass compiles**
+
+Run: `npm run build`
+Expected: build succeeds. If `map-get` emits a deprecation warning that's acceptable; a hard error is not — if it errors, switch to `@use "sass:map"` at the top of `_mixins.scss` and `map.get(...)`.
+
+- [ ] **Step 4: Remove the probe**
+
+Delete the `.__bp_probe` rule. (No git commit — user commits.)
+
+---
+
+### Task 2: `.mystic-btn` mobile override (fixes offenders ①②③)
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_mystic-btn.scss`
+
+**Interfaces:**
+- Consumes: `respond-below(sm)` from Task 1.
+
+Current desktop rule (`_mystic-btn.scss:2-3`): `padding: 2rem 7rem; font-size: 26px;` — 224px horizontal padding overflows a 375px row.
+
+- [ ] **Step 1: Capture the broken state (before)**
+
+Dev server on :3001. Playwright: resize 375×812, navigate to `/en`, click "Summon" flow to reach the tarot post-actions (or open the reader-selection modal), screenshot. Confirm the two mystic buttons overflow / are clipped.
+
+- [ ] **Step 2: Add the mobile override**
+
+Inside `.mystic-btn { ... }`, after the base declarations (before or after `&:hover`), add:
+
+```scss
+  @include respond-below(sm) {
+    padding: 1rem 1.75rem;
+    font-size: 16px;
+    background-size: auto 60%;   // keep the hand-cards art from eating the label
+    background-position: right 0.5rem center;
+  }
+```
+
+- [ ] **Step 3: Verify visually + no overflow**
+
+Playwright at 375px on the same surfaces: screenshot; run the scrollWidth check → `true`. The label must be fully visible and not occluded by the bg image.
+
+- [ ] **Step 4: Regression-check desktop**
+
+Playwright resize 1280×800, navigate `/en`, screenshot — button unchanged from before (padding `2rem 7rem`, font 26px). (User commits.)
+
+---
+
+### Task 3: Tarot post-action buttons stack safely
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_tarot.scss` (post-actions block ~`:164-175`)
+
+**Interfaces:**
+- Consumes: `respond-below(sm)`. Depends on Task 2 (button padding already reduced).
+
+Context: `.tarot__post-actions` is a flex row, `gap: 1.5rem`, two children each `flex: 1 1 30%; min-width: 100px`. After Task 2 the buttons are far narrower, but at 320px two side-by-side may still be tight.
+
+- [ ] **Step 1: Read the current post-actions rule**
+
+Read `_tarot.scss` around lines 160–180 to confirm exact selector names (`.tarot__post-actions`, child button class).
+
+- [ ] **Step 2: Add a mobile column fallback**
+
+Within the post-actions selector, add:
+
+```scss
+  @include respond-below(sm) {
+    flex-direction: column;
+    gap: 1rem;
+    align-items: stretch;
+  }
+```
+
+Only add this if Step 4 of Task 2 verification still showed tightness at 320px; if the row already fits cleanly at 375 and 320, prefer keeping the row and just reducing `gap` to `1rem` at `respond-below(sm)`. Decide from the screenshot evidence, not assumption.
+
+- [ ] **Step 3: Verify at 375px AND 320px**
+
+Playwright resize 320×568 and 375×812, reach post-actions, screenshot each, scrollWidth check → `true`, both buttons fully visible and tappable (min ~44px tall). (User commits.)
+
+---
+
+### Task 4: Global overflow-x safety net
+
+**Files:**
+- Modify: `src/assets/scss/global/_scafolding.scss` (`body` rule, lines 2-9)
+
+**Interfaces:** none. Applied AFTER Tasks 2–3 so it's a net, not the primary fix.
+
+- [ ] **Step 1: Add `overflow-x: hidden` to `body`**
+
+In the existing `body { ... }` block, add `overflow-x: hidden;`.
+
+- [ ] **Step 2: Verify sticky/fixed elements still work**
+
+Playwright at 375px: the header (`position: absolute`), footer `--overlay` (`position: fixed`), and language-switcher dropdown (`position: absolute`) must still render correctly — navigate `/en`, open the language dropdown, screenshot. `overflow-x: hidden` on `body` (not `html`) must not clip the fixed footer or the dropdown.
+
+- [ ] **Step 3: Full-app scroll sweep**
+
+Playwright at 375px, scrollWidth check → `true` on `/en`, `/en/subscription`, `/en/decks`, `/en/contact`, `/en/profile`, `/privacy`. All `true`. (User commits.)
+
+---
+
+### Task 5: Reader-selection modal mobile
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_reader-selection.scss` (summon pane ~`:144`; existing `@media (max-width: 860px)` at `:216`)
+
+**Interfaces:** Consumes `respond-below`. The grid already collapses at 860px; the scroll came from the mystic-btn (fixed in Task 2).
+
+- [ ] **Step 1: Verify Task 2 already killed the horizontal scroll**
+
+Playwright at 375px: open reader-selection modal (main page → "Change your reader"), screenshot, scrollWidth check → `true`. If already clean, only do Step 2 for padding polish.
+
+- [ ] **Step 2: Migrate the existing `max-width: 860px` query to a token + tighten summon-pane padding**
+
+Change the existing `@media (max-width: 860px)` to `@include respond-below(lg)` (900px ≈ 860px; the reader grid `minmax(0,280px)*3` still needs ~900 to fit, so `lg` is the correct token — verify the 3→1 collapse still looks right at 900 and 375). Add inside a `respond-below(sm)` block on the summon pane: reduce its padding so the card content isn't cramped (read the current padding value first; reduce ~30%).
+
+- [ ] **Step 3: Verify at 375px**
+
+Screenshot, scrollWidth → `true`, single centered column, summon button fits. (User commits.)
+
+---
+
+### Task 6: Offer-block title robustness (localized)
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_offer-block.scss` (`.offer-block__title` ~`:141-155`, base font `42px`)
+
+**Interfaces:** Consumes `respond-below`. **Do NOT touch the intro `@keyframes` or animation-delay values** (skip-intro rule). Only adjust font-size / wrapping on the title element.
+
+- [ ] **Step 1: Check the worst-case locale**
+
+Playwright at 375px: navigate `/no` then `/ru` then `/uk`, screenshot the title each time. Confirm whether long words wrap into the moon / overflow.
+
+- [ ] **Step 2: Clamp the title font on small screens**
+
+On `.offer-block__title`, replace the mobile base `font-size: 42px` with a fluid clamp that never exceeds today's value:
+
+```scss
+  font-size: clamp(1.75rem, 9vw, 42px);
+```
+
+Keep `flex-wrap: wrap; gap: 1rem; padding: 0 1.2rem; width: 100%` as-is. This shrinks only where 42px would overflow; at ≥~467px it stays 42px (unchanged desktop-adjacent look). Confirm the `min-width:900` desktop block (100px) is untouched.
+
+- [ ] **Step 3: Re-verify all four locales**
+
+Playwright at 375px on `/en`, `/no`, `/ru`, `/uk`: title fits, does not overlap the moon, scrollWidth → `true`. Desktop (1280px) title still 100px. (User commits.)
+
+---
+
+### Task 7: Header mobile layout
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_main-header.scss`
+- Read: `src/components/MainMenu.tsx` (welcome link class `.main-menu__link`)
+
+**Interfaces:** Consumes `respond-below`. **Do NOT touch `@keyframes headerSlideIn` or the `skip-intro` rule.**
+
+Current: `.main-header { display:flex; gap:2rem; }`, logo 80px mobile. Welcome link has no truncation → long name/localized string pushes the language switcher off-row.
+
+- [ ] **Step 1: Confirm the crowding**
+
+Playwright at 375px, signed-in state if possible (or long-name locale): navigate `/en`, screenshot header. Confirm crowding/wrap.
+
+- [ ] **Step 2: Reduce gap + add padding-inline on mobile**
+
+In `.main-header`, add:
+
+```scss
+  @include respond-below(sm) {
+    gap: 1rem;
+  }
+```
+
+(The header sits inside `.container` which already gives 1rem side padding at mobile — do not add width/flex layout to any reusable child component; keep layout here in the header block.)
+
+- [ ] **Step 3: Truncate the welcome name**
+
+Read `MainMenu.tsx` to confirm the exact class on the welcome text. In its SCSS (`_main-menu.scss`), add a mobile cap so the name ellipsizes rather than wraps:
+
+```scss
+  @include respond-below(sm) {
+    max-width: 45vw;
+    @include trimEllipses;   // existing mixin: ellipsis + nowrap + overflow hidden
+  }
+```
+
+Target the welcome link element specifically (not all menu links) — read the markup to pick the right selector.
+
+- [ ] **Step 4: Verify**
+
+Playwright at 375px: logo + menu + language switcher all on one row, name ellipsized, no wrap, scrollWidth → `true`. Test a long name / `/ru`. (User commits.)
+
+---
+
+### Task 8: Legal-page content guards
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_legal-page.scss`
+
+**Interfaces:** Consumes `respond-below` (optional). The risk is injected Termly HTML with wide tables/`<pre>` (no width guard today).
+
+- [ ] **Step 1: Migrate the raw breakpoint + add width guards**
+
+Change the existing `@media (max-width: 720px)` (line 5) to `@include respond-below(md)` (768px ≈ 720px; verify the top-padding step still looks right). Inside `&__content`, add:
+
+```scss
+  &__content {
+    line-height: 1.7;
+
+    :is(table, pre, img) {
+      max-width: 100%;
+    }
+    table {
+      display: block;
+      overflow-x: auto;   // wide tables scroll inside their box, not the page
+    }
+    pre {
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  }
+```
+
+- [ ] **Step 2: Verify**
+
+Playwright at 375px: navigate `/privacy`, `/terms`, `/cookie-policy`, `/refund`, screenshot each, scrollWidth → `true` (page does not scroll horizontally even if a table does inside its own box). (User commits.)
+
+---
+
+### Task 9: Footer overlay collision
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_main-footer.scss` (`--overlay` variant, lines 7-13)
+- Read: where `.main-footer--overlay` is rendered (grep `main-footer--overlay`)
+
+**Interfaces:** Consumes `respond-below`. The `--overlay` variant is `position: fixed; bottom: 0; pointer-events: none` and can cover bottom CTAs (reader "Summon", tarot post-actions) on 100dvh screens.
+
+- [ ] **Step 1: Confirm which screens use `--overlay` and where it collides**
+
+Grep for `main-footer--overlay` to find the render sites. Playwright at 375×812 and a short height (e.g. 375×640): navigate `/en`, screenshot — check whether the fixed footer legal row overlaps the reader "Summon" button or tarot actions.
+
+- [ ] **Step 2: Prevent the collision**
+
+The footer already has `pointer-events: none` (links re-enable via `pointer-events: auto`), so it does not block clicks — the issue is visual overlap. On mobile, keep the overlay footer out of the CTA zone. Add to `.main-footer--overlay`:
+
+```scss
+    @include respond-below(sm) {
+      // On short mobile screens the fixed footer must not sit on top of
+      // primary CTAs; drop the disclaimer/legal block's visual weight here.
+      .main-footer__disclaimer { display: none; }
+    }
+```
+
+Decide the exact reduction from the screenshot evidence — if only the disclaimer overlaps, hiding it on mobile overlay is enough; if the legal row also overlaps, additionally reduce its `font-size`/`margin` at `respond-below(sm)`. Do not change desktop.
+
+- [ ] **Step 3: Verify**
+
+Playwright at 375×640 and 375×812: reader "Summon" and tarot post-actions are fully visible and not covered by the footer; scrollWidth → `true`. (User commits.)
+
+---
+
+### Task 10: User-profile cosmetics
+
+**Files:**
+- Modify: `src/assets/scss/blocks/_user-profile.scss` (`.profile-page` padding `:2`, title `:11`)
+
+**Interfaces:** Consumes `respond-below`. Current: `.profile-page { padding: 160px 0 100px }` and `.profile-page__title { font-size: 2.5rem }` — no mobile reduction.
+
+- [ ] **Step 1: Add mobile padding + title step-down**
+
+```scss
+  .profile-page {
+    @include respond-below(sm) {
+      padding: 100px 0 80px;
+    }
+  }
+  .profile-page__title {
+    @include respond-below(sm) {
+      font-size: 1.9rem;
+    }
+  }
+```
+
+(Match exact nesting/selector structure of the existing file — read it first to place these inside the right blocks.)
+
+- [ ] **Step 2: Verify**
+
+Playwright at 375px: navigate `/en/profile` (signed-in), screenshot — reduced top gap, title fits one/two lines, credits/deck/reader rows readable, scrollWidth → `true`. (User commits.)
+
+---
+
+### Task 11: QA sweep of the already-correct pages
+
+**Files:** none expected — verification only. If a real break is found, fix at that file's existing breakpoint using `respond-below` and note it.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Screenshot sweep at 375px**
+
+Playwright resize 375×812, navigate and screenshot each, scrollWidth → `true` on all:
+- `/en/subscription` — 4-col → single column
+- `/en/decks` — 3-col → single column
+- `/en/contact` — form full-width, submit fits
+- base modal — open login modal, full-screen mobile
+- `/payment/result` — centered, fits
+- `/en` tarot 3-card grid — 3×100px cards fit (open the reading flow)
+
+- [ ] **Step 2: 320px edge check**
+
+Repeat the sweep at 320×568 for the two tightest (tarot 3-card grid, subscription). scrollWidth → `true`.
+
+- [ ] **Step 3: Final build**
+
+Run: `npm run build`
+Expected: succeeds (Sass compiles, no type errors). (User commits the whole branch when satisfied.)
+
+---
+
+## Self-Review
+
+**Spec coverage:** Breakpoint mixin → Task 1. `.mystic-btn` → Task 2. Overflow-x net → Task 4. Tarot post-actions → Task 3. Reader modal → Task 5. Offer-block title → Task 6. Header → Task 7. Legal tables → Task 8. Footer overlay → Task 9. Profile cosmetics → Task 10. QA the correct 6 → Task 11. All spec fixes mapped.
+
+**Ordering note:** Task 4 (overflow net) runs after Tasks 2–3 per the spec (net, not primary fix). Task 3 depends on Task 2's narrower button. All other tasks are independent and could run in any order after Task 1.
+
+**Placeholder scan:** No TBD/TODO; every code step shows concrete code; verification steps give exact viewport + assertion.
+
+**Type/name consistency:** `respond-below`/`respond-above` and `$breakpoints` tokens `sm`/`md`/`lg` used consistently across all tasks. `trimEllipses` and `link-style` are existing mixins in `_mixins.scss`.
+
+**Known judgement points (intentional, evidence-driven, not placeholders):** Task 3 row-vs-column and Task 9 disclaimer-vs-legal-row are decided from screenshot evidence during execution, with the default spelled out.

--- a/docs/superpowers/specs/2026-07-02-mobile-responsive-pass-design.md
+++ b/docs/superpowers/specs/2026-07-02-mobile-responsive-pass-design.md
@@ -1,0 +1,77 @@
+# Mobile Responsive Pass — Design
+
+**Date:** 2026-07-02
+**Status:** Approved (design), pending implementation plan
+**Scope:** Full pre-launch mobile-responsive fix across all pages/screens of "The Veil".
+
+## Problem
+
+Mobile (320–480px) is the #1 pre-launch blocker. A per-page audit (viewport 375px) found the breakage is **not** uniform — several pages already collapse correctly. It concentrates in a few reused primitives and missing infrastructure.
+
+### Root causes
+1. **`.mystic-btn` has no mobile override.** `_mystic-btn.scss:2-3`: `padding: 2rem 7rem` (224px horizontal) + `font-size: 26px` + a right-aligned `hand-with-cards.png` bg. The button needs ~300–360px before text. It is reused on the **3 most-broken surfaces**, so one rule fixes all three.
+2. **No global `overflow-x` guard.** Nothing stops app-wide horizontal scroll; some wrappers (`.offer-block`, `.tarot-modal__inner`) merely *clip* overflow (hiding broken buttons), and surfaces without such a wrapper get real horizontal scroll.
+3. **No shared breakpoint.** Every surface switches mobile↔desktop at a different width: 600 / 700 / 720 / 768 / 860 / 900 / 960px. No mixin in `_mixins.scss`.
+
+### Ranked worst offenders
+1. Tarot post-action buttons (`_tarot.scss:164-175` + `.mystic-btn`) — two 224px-padded buttons in one 375px row; only hidden by `overflow:hidden`.
+2. Reader-selection modal (`ReaderSelection.tsx:128`, `_reader-selection.scss:144`, `_modal.scss:24`) — same button, but causes real horizontal scroll inside the `overflow-y:auto` modal.
+3. Offer-block "Summon" (`OfferBlock.tsx:169-178`) — same button clipped behind bg image; plus a fragile absolutely-positioned 42px title (`_offer-block.scss:152`) that risks wrap/overflow in non-English locales.
+4. Header (`_main-header.scss:1-8`, `MainMenu.tsx:20`) — `gap:2rem` + non-truncated welcome/name + no mobile layout.
+5. Legal-page content (`_legal-page.scss` + injected Termly HTML) — no table/wide-element width guard → probable horizontal scroll from tables.
+6. Footer overlay (`_main-footer.scss:6-13`) — `position:fixed; bottom:0` overlay can cover primary CTAs on short 100dvh screens.
+7. User profile (`_user-profile.scss:2,11`) — cosmetic: no mobile padding/title reduction.
+
+### Already correct (QA only, no fix expected)
+Subscription, decks, contact form, base modal, payment result, and the tarot 3-card grid. All use an explicit `max-width` mobile breakpoint — the model to copy.
+
+### Global foundation (verified OK)
+- Viewport meta correct (`src/app/layout.tsx:11-15`, `width=device-width, initial-scale=1`, no max-scale lock).
+- `.container` mobile-safe (`_container.scss`: base `width:100%; padding:0 1rem`; `max-width:1300px` only at `min-width:900`).
+- Global `img { width:100%; height:auto }` (`_scafolding.scss`, `_normalize.scss`) — but overridden by fixed `!important` px on deck/tarot cards and `next/image` props, so it does not protect those.
+
+## Approach
+
+### Breakpoint infrastructure (`_mixins.scss`)
+Single source of truth for breakpoint *values*, helpers for both directions:
+
+```scss
+@use "sass:map";
+$breakpoints: (sm: 37.5em, md: 48em, lg: 56.25em);   // 600 / 768 / 900px
+
+@mixin respond-below($bp) { @media (max-width: map.get($breakpoints, $bp)) { @content } }
+@mixin respond-above($bp) { @media (min-width: map.get($breakpoints, $bp)) { @content } }
+```
+
+**Decision — unify the values, keep each file's direction.** The codebase is genuinely mixed: offer-block/tarot/header are mobile-first (base = mobile, `min-width:900` adds desktop); subscription/decks are desktop-first (base = desktop, `max-width:720` adds mobile). Fully converting the mobile-first files to one convention means rewriting their entire desktop + animation blocks — high risk, near-zero payoff, and it collides with the "don't touch animations blindly" rule. So we collapse the 7 raw pixel values to **3 named tokens** and each file keeps its existing direction, swapping raw px → token as we touch it. The stray 720→768 and 960→900 nudges land only on QA'd (already-correct) pages and are safe.
+
+> Note on Sass `@import`: the project uses legacy `@import` in `style.scss`. `_mixins.scss` will need `@use "sass:map"` (or `map-get` legacy syntax) — use whichever the current Dart Sass setup compiles cleanly. Verify with `npm run build` before proceeding.
+
+### Fixes (execution order)
+1. **`.mystic-btn` mobile** (`_mystic-btn.scss`) — `respond-below(sm)`: padding `2rem 7rem` → ~`1rem 1.75rem`, font 26 → 16px, constrain the `hand-with-cards` bg so the label is never occluded. Fixes offenders ①②③.
+2. **Global overflow-x net** (`_scafolding.scss`) — `overflow-x: hidden` on `body`, applied *after* the real fixes as belt-and-suspenders (not the primary mechanism). Must not break any `position: sticky`/`fixed` behavior — verify header/footer/language-switcher still work.
+3. **Tarot post-actions** (`_tarot.scss`) — verify the two buttons fit after #1; if still tight at 320px, stack to a column (`flex-direction: column`) via `respond-below(sm)`.
+4. **Reader-selection modal** (`_reader-selection.scss`) — confirm horizontal scroll gone after #1; tighten summon-pane padding at mobile.
+5. **Offer-block title** (`_offer-block.scss`) — robustness for localized long words at 42px: clamp/reduce font on small screens, guard against wrapping into the moon. Do NOT alter the intro animation keyframes; only adjust font-size/wrapping within the existing mobile base.
+6. **Header** (`_main-header.scss`, `MainMenu.tsx`) — reduce `gap` on mobile; truncate/ellipsize the welcome name (`.main-menu__link`) so a long name or localized string can't push the language switcher off-row.
+7. **Legal tables** (`_legal-page.scss`) — add `.legal-page__content :is(table, pre, img) { max-width: 100% }` + `.legal-page__content table { display: block; overflow-x: auto }`.
+8. **Footer overlay** (`_main-footer.scss`) — prevent the fixed-bottom `--overlay` variant from covering bottom CTAs on 100dvh screens (e.g. constrain to non-CTA screens, or make it non-blocking where CTAs sit).
+9. **Profile cosmetics** (`_user-profile.scss`) — mobile padding `160px 0 100px` → ~`100px 0 80px`; title `2.5rem` step-down at `respond-below(sm)`.
+10. **QA the correct 6** — visually verify subscription, decks, contact, base modal, payment result, tarot 3-card grid at 375px; no fixes expected.
+
+### Verification
+- Dev server on **:3001** (project runs there, not 3000).
+- Drive with the **Playwright MCP** at a 375px viewport: load each page, screenshot, assert no horizontal scroll (`document.documentElement.scrollWidth <= innerWidth`) and CTAs fit.
+- Check at least one non-English locale (e.g. `/no` or `/ru`) on the offer-block title.
+- Run `npm run build` to confirm the new Sass mixin compiles.
+
+## Constraints honored
+- No new colors — existing CSS custom properties only.
+- Never `opacity` for text color — use `--text-soft` / `--text-faint`.
+- No wildcard (`*`) animation overrides; understand each keyframe/delay before touching.
+- No layout (flex/width) baked into reusable components — parent owns layout.
+- No git writes — user commits themselves.
+- Always use Opus for any subagent.
+
+## Out of scope
+Other TODO UX items (intro-replay-once-per-session, subscription modal redesign, anon paywall message) — separate specs. This pass is responsive layout only.

--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -8,6 +8,7 @@ import { Modal } from "@/components/Modal";
 import { LoginForm } from "@/components/LoginForm";
 import { SubscriptionPlans } from "@/components/SubscriptionPlans";
 import { Header } from "@/components/Header";
+import Footer from "@/components/Footer";
 import { Providers } from "@/components/Providers";
 import { LoginContext } from "@/components/LoginContext";
 
@@ -24,11 +25,12 @@ export function HomePageClient() {
           onOpenLogin={() => setIsLoginOpen(true)}
           onOpenSubscription={() => setIsSubscriptionOpen(true)}
         />
-        <Tarot
-          onOpenLogin={() => setIsLoginOpen(true)}
-          onOpenSubscription={() => setIsSubscriptionOpen(true)}
-        />
       </main>
+      <Tarot
+        onOpenLogin={() => setIsLoginOpen(true)}
+        onOpenSubscription={() => setIsSubscriptionOpen(true)}
+      />
+      <Footer overlay />
       <Modal
         title={t("stepThroughTheVeil")}
         isOpen={isLoginOpen}

--- a/src/assets/scss/_mixins.scss
+++ b/src/assets/scss/_mixins.scss
@@ -67,3 +67,24 @@
   border: 1px solid !important;
   border-image: repeating-linear-gradient(45deg, var(--primary), transparent, var(--primary) 10px) 10 !important;
 }
+
+// ── Responsive breakpoints ──
+// Single source of truth. Files keep their existing mobile-first (respond-above)
+// or desktop-first (respond-below) direction; only the VALUE is centralized.
+$breakpoints: (
+  sm: 37.5em,   // 600px
+  md: 48em,     // 768px
+  lg: 56.25em,  // 900px
+);
+
+@mixin respond-below($bp) {
+  @media (max-width: map-get($breakpoints, $bp)) {
+    @content;
+  }
+}
+
+@mixin respond-above($bp) {
+  @media (min-width: map-get($breakpoints, $bp)) {
+    @content;
+  }
+}

--- a/src/assets/scss/blocks/_cookie-banner.scss
+++ b/src/assets/scss/blocks/_cookie-banner.scss
@@ -2,7 +2,7 @@
   position: fixed;
   inset-inline: 0;
   bottom: 0;
-  z-index: 20;
+  z-index: 60; // above the overlay footer (50), below modals (100)
   background-color: var(--bg);
   border-top: var(--border);
   border-image: repeating-linear-gradient(

--- a/src/assets/scss/blocks/_form.scss
+++ b/src/assets/scss/blocks/_form.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  padding: 1rem;
   width: 100%;
   .form__input-block {
     display: flex;

--- a/src/assets/scss/blocks/_legal-page.scss
+++ b/src/assets/scss/blocks/_legal-page.scss
@@ -2,12 +2,27 @@
   padding-top: 160px;
   min-height: 100dvh;
 
-  @media (max-width: 720px) {
+  @include respond-below(md) {
     padding-top: 120px;
   }
 
   &__content {
     line-height: 1.7;
+    overflow-wrap: break-word; // wrap long URLs/emails in Termly HTML instead of overflowing
+
+    :is(table, pre, img) {
+      max-width: 100%;
+    }
+
+    table {
+      display: block;
+      overflow-x: auto; // wide Termly tables scroll in their own box, not the page
+    }
+
+    pre {
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
   }
 
   &__attribution {

--- a/src/assets/scss/blocks/_loader.scss
+++ b/src/assets/scss/blocks/_loader.scss
@@ -9,7 +9,7 @@
   width: 100%;
   height: 100dvh;
   background-color: var(--bg);
-  z-index: 10;
+  z-index: 70; // full-screen loading overlay: above footer (50) + cookie banner (60)
 
   svg {
     width: 100px;

--- a/src/assets/scss/blocks/_main-footer.scss
+++ b/src/assets/scss/blocks/_main-footer.scss
@@ -8,8 +8,17 @@
     position: fixed;
     inset-inline: 0;
     bottom: 0;
-    z-index: 10;
+    z-index: 50; // above the tarot reading screen (40), below cookie banner (60) + modals (100)
     pointer-events: none;
+
+    // On short mobile screens the fixed footer must not sit on top of the
+    // primary CTAs (reader "Summon", tarot post-actions). Drop the tall
+    // disclaimer block here; the legal links row stays.
+    @include respond-below(sm) {
+      .main-footer__disclaimer {
+        display: none;
+      }
+    }
   }
 
   .main-footer__link {

--- a/src/assets/scss/blocks/_main-header.scss
+++ b/src/assets/scss/blocks/_main-header.scss
@@ -7,7 +7,11 @@
   align-items: center;
   gap: 2rem;
   padding-top: 1rem;
-  z-index: 100;
+  z-index: 30; // layer scale: content < header(30) < tarot-screen(40) < footer(50) < banner(60) < modal(100)
+
+  @include respond-below(sm) {
+    gap: 1rem;
+  }
   opacity: 0;
   transform: translateY(-20px);
   animation: headerSlideIn 1s ease-out 1.5s forwards;

--- a/src/assets/scss/blocks/_main-menu.scss
+++ b/src/assets/scss/blocks/_main-menu.scss
@@ -13,6 +13,11 @@
     padding: 0.5rem;
     text-transform: capitalize;
     border: none;
+
+    @include respond-below(sm) {
+      max-width: 45vw;
+      @include trimEllipses; // ellipsis a long welcome name instead of wrapping the row
+    }
   }
 
   .main-menu__welcome {

--- a/src/assets/scss/blocks/_modal.scss
+++ b/src/assets/scss/blocks/_modal.scss
@@ -45,6 +45,10 @@
     margin-block: 0 2.5rem;
     padding: 0;
     border: none;
+
+    @include respond-above(md) {
+      margin-bottom: 5rem;
+    }
   }
 }
 

--- a/src/assets/scss/blocks/_mystic-btn.scss
+++ b/src/assets/scss/blocks/_mystic-btn.scss
@@ -18,6 +18,13 @@
   cursor: pointer;
   transition: all 0.5s ease-in-out;
 
+  @include respond-below(sm) {
+    padding: 1rem 1.75rem;
+    font-size: 16px;
+    background-size: auto 60%;
+    background-position: right 0.5rem center;
+  }
+
   &:hover {
     color: var(--text-soft);
     transform: scale(0.99);

--- a/src/assets/scss/blocks/_offer-block.scss
+++ b/src/assets/scss/blocks/_offer-block.scss
@@ -63,14 +63,22 @@
     .inner-wrap {
       position: absolute;
       left: 50%;
-      bottom: 0;
+      // Reserve space for the fixed overlay footer (measured: 108px < sm, 125px ≥ sm).
+      // Raising `bottom` while shrinking `height` keeps the band's TOP edge fixed,
+      // so only the reader/deck lift up — the moon + title animation is untouched.
+      bottom: 108px;
       display: flex;
       align-items: center;
       justify-content: center;
       width: 100%;
-      height: 70%;
+      height: calc(70% - 108px);
       transform: translate(-50%, 0);
       transition: opacity 0.8s ease, transform 0.8s ease;
+
+      @include respond-above(sm) {
+        bottom: 125px;
+        height: calc(70% - 125px);
+      }
     }
 
     .inner-wrap--reader {
@@ -149,7 +157,7 @@
     margin-top: 0;
     padding: 0 1.2rem;
     width: 100%;
-    font-size: 42px;
+    font-size: clamp(1.75rem, 9vw, 42px); // shrink only where 42px would overflow (long localized words)
     z-index: 1;
     transform: translate(-50%, -100%);
   }

--- a/src/assets/scss/blocks/_reader-selection.scss
+++ b/src/assets/scss/blocks/_reader-selection.scss
@@ -213,7 +213,7 @@
     }
   }
 
-  @media (max-width: 860px) {
+  @include respond-below(lg) {
     padding: 40px 20px 32px;
     gap: 32px;
 
@@ -225,6 +225,15 @@
     &__card {
       aspect-ratio: auto;
       min-height: 280px;
+    }
+  }
+
+  @include respond-below(sm) {
+    padding: 32px 16px 24px;
+    gap: 24px;
+
+    &__summon-pane {
+      gap: 16px;
     }
   }
 }

--- a/src/assets/scss/blocks/_tarot.scss
+++ b/src/assets/scss/blocks/_tarot.scss
@@ -1,7 +1,7 @@
 .tarot-modal {
   position: fixed;
   inset: 0;
-  z-index: 100;
+  z-index: 40; // full-screen reading screen: above header, below overlay footer + modals
   background-color: var(--bg);
   opacity: 0;
   animation: tarotModalFadeIn 0.5s ease-out forwards;
@@ -171,6 +171,16 @@
     flex: 1 1 30%;
     min-width: 100px;
     text-align: left;
+  }
+
+  @include respond-below(sm) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+
+    .mystic-btn {
+      flex: 1 1 auto;
+    }
   }
 }
 

--- a/src/assets/scss/blocks/_title.scss
+++ b/src/assets/scss/blocks/_title.scss
@@ -8,6 +8,16 @@
     font-size: 35px;
     border: var(--border);
     border-radius: var(--border-radius);
+
+    // Modal titles (reading result, login, reader select, etc. — all use this
+    // modifier): smaller + left-aligned on mobile, full size + centered at md+.
+    // width:100% is required — the modal content is a center-aligned flex column,
+    // so without it the title shrinks to content width and text-align has no effect.
+    @include respond-below(md) {
+      width: 100%;
+      font-size: 20px;
+      text-align: left;
+    }
   }
 
   &--third {

--- a/src/assets/scss/blocks/_user-profile.scss
+++ b/src/assets/scss/blocks/_user-profile.scss
@@ -8,12 +8,21 @@
   flex-direction: column;
   align-items: center;
 
+  @include respond-below(sm) {
+    padding: 100px 0 80px;
+  }
+
   &__title {
     font-size: 2.5rem;
     letter-spacing: 0.04em;
     margin: 0 0 48px;
     color: var(--primary);
     text-align: center;
+
+    @include respond-below(sm) {
+      font-size: 1.9rem;
+      margin: 0 0 32px;
+    }
   }
 }
 

--- a/src/assets/scss/global/_scafolding.scss
+++ b/src/assets/scss/global/_scafolding.scss
@@ -6,6 +6,7 @@ body {
   font-weight: var(--font-weight);
   color: var(--text-color);
   background-color: var(--bg);
+  overflow-x: hidden; // safety net against stray horizontal scroll on small screens
 }
 
 button {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,10 @@ type HeaderProps = {
 
 export const Header = ({onOpenLogin}: HeaderProps) => {
     const [skipIntro] = useState(() => {
+        // SSR must be deterministic and match a fresh client load (intro plays).
+        // Never read/mutate the module flag on the server — it persists across
+        // requests and would desync server vs. client HTML (hydration mismatch).
+        if (typeof window === "undefined") return false;
         const skip = hasPlayedHeaderIntro;
         hasPlayedHeaderIntro = true;
         return skip;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { createPortal } from "react-dom";
 import Skull from "../assets/svg/skull.svg";
 
 type ModalProps = {
@@ -27,9 +28,11 @@ export const Modal = ({ isOpen, onClose, title, children, wide }: ModalProps) =>
     };
   }, [isOpen]);
 
-  if (!isOpen) return null;
+  if (!isOpen || typeof document === "undefined") return null;
 
-  return (
+  // Portal to body so the modal escapes any parent stacking context (e.g. the
+  // fixed .tarot-modal) and layers globally above the overlay footer.
+  return createPortal(
     <div className="modal" onClick={onClose}>
       <div className={`modal__content${wide ? " modal__content--wide" : ""}`} onClick={(e) => e.stopPropagation()}>
         <button className="modal__close" onClick={onClose}>
@@ -38,6 +41,7 @@ export const Modal = ({ isOpen, onClose, title, children, wide }: ModalProps) =>
         <h2 className="title title--secondary modal__title">{title}</h2>
         {children}
       </div>
-    </div>
+    </div>,
+    document.body
   );
 };

--- a/src/components/OfferBlock.tsx
+++ b/src/components/OfferBlock.tsx
@@ -8,7 +8,6 @@ import Medallion4 from "../assets/svg/medallion4.svg";
 import Medallion5 from "../assets/svg/medallion5.svg";
 import Medallion6 from "../assets/svg/medallion6.svg";
 import {SmokeAnimation} from "@/components/SmokeAnimation";
-import Footer from "@/components/Footer";
 import {useEffect, useState} from "react";
 import { useTranslations, useMessages } from "next-intl";
 import {useSession} from "next-auth/react";
@@ -19,6 +18,7 @@ import {READERS, DEFAULT_READER} from "@/lib/readers";
 import {ReaderSelection} from "@/components/ReaderSelection";
 import {Modal} from "@/components/Modal";
 import {MysticButton} from "@/components/MysticButton";
+import { Loader } from "@/components/Loader";
 import { useReadingGate } from "@/hooks/useReadingGate";
 
 type OfferBlockProps = {
@@ -36,6 +36,10 @@ export const OfferBlock = ({
     const { state, setState } = useAppContext();
     const t = useTranslations("ui");
     const [skipIntro] = useState(() => {
+        // SSR must be deterministic and match a fresh client load (intro plays).
+        // Never read/mutate the module flag on the server — it persists across
+        // requests and would desync server vs. client HTML (hydration mismatch).
+        if (typeof window === "undefined") return false;
         const skip = hasPlayedIntro;
         hasPlayedIntro = true;
         return skip;
@@ -114,7 +118,7 @@ export const OfferBlock = ({
     return (
         <section className={`offer-block${isLoaded ? " loaded" : ""}${skipIntro ? " skip-intro" : ""}`}>
             {!isLoaded
-                ? <div>{t("loading")}</div>
+                ? <Loader />
                 : (
                     <>
                         <SmokeAnimation/>
@@ -230,7 +234,6 @@ export const OfferBlock = ({
                                 />
                             </Modal>
                         )}
-                        <Footer overlay />
                     </>
                 )
             }

--- a/src/components/Tarot.tsx
+++ b/src/components/Tarot.tsx
@@ -11,7 +11,6 @@ import LoaderSvg from "@/assets/svg/ouroboros.svg";
 import {useAppContext} from "@/AppProvider";
 import {MysticButton} from "@/components/MysticButton";
 import { useReadingGate } from "@/hooks/useReadingGate";
-import Footer from "@/components/Footer";
 
 type TarotProps = {
     onOpenLogin: () => void;
@@ -174,7 +173,6 @@ export const Tarot = ({ onOpenLogin, onOpenSubscription }: TarotProps) => {
                         {state.response && <p className="tarot__result-text">{state.response}</p>}
                     </div>
                 </Modal>
-                <Footer overlay />
             </div>
         </div>
     );


### PR DESCRIPTION
  - add responsive breakpoint mixins (sm/md/lg); fix mobile across offer-block, tarot, header, reader modal, legal, footer, profile
  - unify overlay footer to one instance out of <main>; establish z-index layer scale; Modal portals to body
  - reserve responsive footer space in offer-block (108/125px)
  - fix SSR hydration mismatch: skip-intro flags no longer mutate on server
  - restore ouroboros Loader (SEO refactor left an unstyled text node)
  - modal title 20px/left on mobile; drop form padding