### PR TITLE
feat(profile): unify fields into label–value rows with edit-icon modals

### DIFF
--- a/messages/no/ui.json
+++ b/messages/no/ui.json
@@ -108,7 +108,7 @@
     "deleteAccountEmailBody": "Your account at The Veil has been permanently deleted. This action is irreversible. If you did not request this, contact privacy@nothingweird.agency.",
     "renewsOn": "Renews on {date}",
     "accessUntil": "Access until {date}",
-    "renewal": "Renewal",
+    "renewal": "Fornyelse",
     "cancelSubscription": "Cancel subscription",
     "resumeSubscription": "Resume subscription",
     "cancelSubscriptionConfirm": "Cancel auto-renew? You'll keep access until the end of your paid period.",

--- a/messages/tr/ui.json
+++ b/messages/tr/ui.json
@@ -108,7 +108,7 @@
     "deleteAccountEmailBody": "Your account at The Veil has been permanently deleted. This action is irreversible. If you did not request this, contact privacy@nothingweird.agency.",
     "renewsOn": "Renews on {date}",
     "accessUntil": "Access until {date}",
-    "renewal": "Renewal",
+    "renewal": "Yenileme",
     "cancelSubscription": "Cancel subscription",
     "resumeSubscription": "Resume subscription",
     "cancelSubscriptionConfirm": "Cancel auto-renew? You'll keep access until the end of your paid period.",

--- a/messages/uk/ui.json
+++ b/messages/uk/ui.json
@@ -108,7 +108,7 @@
     "deleteAccountEmailBody": "Your account at The Veil has been permanently deleted. This action is irreversible. If you did not request this, contact privacy@nothingweird.agency.",
     "renewsOn": "Renews on {date}",
     "accessUntil": "Access until {date}",
-    "renewal": "Renewal",
+    "renewal": "Поновлення",
     "cancelSubscription": "Cancel subscription",
     "resumeSubscription": "Resume subscription",
     "cancelSubscriptionConfirm": "Cancel auto-renew? You'll keep access until the end of your paid period.",

--- a/src/assets/scss/blocks/_decks.scss
+++ b/src/assets/scss/blocks/_decks.scss
@@ -125,3 +125,11 @@
     }
   }
 }
+
+// Deck grid rendered inside the profile's picker Modal — strip the page chrome
+// (the Modal supplies its own frame + padding). Compound selector so it wins
+// over `.decks` and its media query regardless of import order.
+.decks.decks--modal {
+  padding: 0;
+  background: transparent;
+}

--- a/src/assets/scss/blocks/_user-profile.scss
+++ b/src/assets/scss/blocks/_user-profile.scss
@@ -33,11 +33,61 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  width: 100%;
+  max-width: 420px;
 
   .user-profile__field {
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
+
+    // Rows that open a picker modal (deck / reader / language): label left,
+    // value + edit icon right, on a single line.
+    &--row {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+  }
+
+  .user-profile__value-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    min-width: 0;
+
+    .user-profile__value {
+      @include trimEllipses;
+    }
+  }
+
+  .user-profile__edit-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    padding: 0.25rem;
+    background: none;
+    border: none;
+    color: var(--primary);
+    cursor: pointer;
+    transition: color 0.2s, transform 0.2s;
+
+    svg {
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover:not(:disabled) {
+      color: var(--text-soft);
+      transform: scale(1.1);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
   }
 
   .user-profile__label {
@@ -50,34 +100,6 @@
   .user-profile__value {
     font-size: 1.1rem;
     color: var(--primary);
-
-    &--editable {
-      cursor: pointer;
-      border-bottom: 1px dashed var(--border-color);
-      padding-bottom: 0.15rem;
-      transition: border-color 0.2s;
-
-      &:hover {
-        border-bottom-color: var(--primary);
-      }
-    }
-  }
-
-  .user-profile__upgrade {
-    margin-left: 1rem;
-    color: var(--primary);
-    text-decoration: none;
-    cursor: pointer;
-    transition: text-decoration 0.2s;
-    background: none;
-    border: none;
-    padding: 0;
-    font: inherit;
-
-    &:hover {
-      text-decoration: underline;
-      text-decoration-style: dashed;
-    }
   }
 
   .user-profile__edit {
@@ -157,39 +179,6 @@
     font-size: 20px;
   }
 
-  .user-profile__language-options {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-  }
-
-  .user-profile__language-option {
-    padding: 0.35rem 0.9rem;
-    font-size: 0.95rem;
-    font-family: var(--font-family);
-    color: var(--text-faint);
-    background-color: transparent;
-    border: var(--border);
-    border-radius: var(--border-radius);
-    cursor: pointer;
-    transition: color 0.2s, background-color 0.2s, border-color 0.2s;
-
-    &:hover:not(:disabled):not(&--active) {
-      color: var(--text-color);
-    }
-
-    &:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    &--active {
-      color: var(--primary);
-      background-color: rgba(250, 225, 163, 0.15);
-      cursor: default;
-    }
-  }
-
   .user-profile__danger-zone {
     margin-top: 3rem;
     display: flex;
@@ -233,6 +222,93 @@
     &:hover {
       background-color: rgba(231, 76, 60, 0.12);
       border-color: var(--error);
+    }
+  }
+}
+
+// Radio-list picker modal (language). Title comes from <Modal>.
+.options-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__item {
+    border-bottom: 1px solid var(--border-color);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    padding: 1rem 0.25rem;
+    cursor: pointer;
+  }
+
+  &__radio-input {
+    @include visually-hidden;
+  }
+
+  &__radio {
+    position: relative;
+    flex: 0 0 auto;
+    width: 20px;
+    height: 20px;
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    transition: border-color 0.2s;
+  }
+
+  &__radio-input:checked + &__radio {
+    border-color: var(--primary);
+
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 4px;
+      border-radius: 50%;
+      background-color: var(--primary);
+    }
+  }
+
+  &__option-label {
+    font-size: 1.05rem;
+    color: var(--text-soft);
+  }
+
+  &__radio-input:checked ~ &__option-label {
+    color: var(--primary);
+  }
+
+  &__save {
+    align-self: center;
+    margin-top: 0.5rem;
+    padding: 0.85rem 3rem;
+    font-family: var(--font-family);
+    font-size: 1rem;
+    color: var(--primary);
+    background-color: transparent;
+    border: var(--border);
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s;
+
+    &:hover:not(:disabled) {
+      background-color: rgba(250, 225, 163, 0.12);
+      border-color: var(--primary);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
   }
 }

--- a/src/assets/svg/edit.svg
+++ b/src/assets/svg/edit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.375 2.625a1 1 0 0 1 3 3l-9.013 9.014a2 2 0 0 1-.853.505l-2.873.84a.5.5 0 0 1-.62-.62l.84-2.873a2 2 0 0 1 .506-.852z"/></svg>

--- a/src/components/DeckSelector.tsx
+++ b/src/components/DeckSelector.tsx
@@ -12,7 +12,7 @@ const DECK_NAME_KEYS: Record<DeckId, string> = {
   "Gothic-Vintage": "deckGothicVintage",
 };
 
-export const DeckSelector = () => {
+export const DeckSelector = ({ inModal = false }: { inModal?: boolean } = {}) => {
   const { data: session, update } = useSession();
   const t = useTranslations("ui");
   const [currentDeck, setCurrentDeck] = useState<string>(DEFAULT_DECK);
@@ -46,52 +46,63 @@ export const DeckSelector = () => {
     }
   };
 
+  const grid = (
+    <>
+      <div className="decks__grid">
+        {DECK_IDS.map((id) => {
+          const deck = DECKS[id];
+          const isSelected = id === currentDeck;
+          const cardClass = isSelected
+            ? "decks__card decks__card--selected"
+            : "decks__card";
+
+          return (
+            <article key={id} className={cardClass}>
+              {isSelected && (
+                <span className="decks__badge">{t("selected")}</span>
+              )}
+              <Image
+                className="decks__preview"
+                src={deck.preview}
+                alt={t(DECK_NAME_KEYS[id])}
+                width={160}
+                height={280}
+              />
+              <h2 className="decks__card-name">{t(DECK_NAME_KEYS[id])}</h2>
+              {session ? (
+                <button
+                  type="button"
+                  className="decks__cta"
+                  disabled={isSelected || isSaving}
+                  onClick={() => handleSelect(id)}
+                >
+                  {isSelected ? t("selected") : t("selectDeck")}
+                </button>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+
+      {!session && (
+        <p className="decks__sign-in-prompt">{t("signInToSelectDeck")}</p>
+      )}
+    </>
+  );
+
+  // In a modal, skip the page chrome (section / container / page title) — the
+  // Modal supplies its own frame and title.
+  if (inModal) {
+    return <div className="decks decks--modal">{grid}</div>;
+  }
+
   return (
     <section className="decks">
       <div className="container">
         <header className="decks__header">
           <h1 className="decks__title">{t("chooseDeck")}</h1>
         </header>
-
-        <div className="decks__grid">
-          {DECK_IDS.map((id) => {
-            const deck = DECKS[id];
-            const isSelected = id === currentDeck;
-            const cardClass = isSelected
-              ? "decks__card decks__card--selected"
-              : "decks__card";
-
-            return (
-              <article key={id} className={cardClass}>
-                {isSelected && (
-                  <span className="decks__badge">{t("selected")}</span>
-                )}
-                <Image
-                  className="decks__preview"
-                  src={deck.preview}
-                  alt={t(DECK_NAME_KEYS[id])}
-                  width={160}
-                  height={280}
-                />
-                <h2 className="decks__card-name">{t(DECK_NAME_KEYS[id])}</h2>
-                {session ? (
-                  <button
-                    type="button"
-                    className="decks__cta"
-                    disabled={isSelected || isSaving}
-                    onClick={() => handleSelect(id)}
-                  >
-                    {isSelected ? t("selected") : t("selectDeck")}
-                  </button>
-                ) : null}
-              </article>
-            );
-          })}
-        </div>
-
-        {!session && (
-          <p className="decks__sign-in-prompt">{t("signInToSelectDeck")}</p>
-        )}
+        {grid}
       </div>
     </section>
   );

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -2,15 +2,23 @@
 
 import { useState, useEffect } from "react";
 import { useSession, signOut } from "next-auth/react";
-import { Link, useRouter, usePathname } from "@/i18n/navigation";
+import { useRouter, usePathname } from "@/i18n/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { routing } from "@/i18n/routing";
 import { type PlanId } from "@/lib/plans";
 import { type ReaderId } from "@/lib/readers";
 import { ReaderSelectionModal } from "@/components/ReaderSelectionModal";
+import { DeckSelector } from "@/components/DeckSelector";
 import { Modal } from "@/components/Modal";
+import EditIcon from "@/assets/svg/edit.svg";
 
 const DELETE_CONFIRMATION_TOKEN = "DELETE";
+
+// ISO date → dd/mm/yy
+const formatDate = (iso: string) => {
+  const [y, m, d] = iso.slice(0, 10).split("-");
+  return `${d}/${m}/${y.slice(2)}`;
+};
 
 const LOCALE_NAMES: Record<string, string> = {
   en: "English",
@@ -43,6 +51,9 @@ export const UserProfile = () => {
   const [deckId, setDeckId] = useState<string | null>(null);
   const [readerId, setReaderId] = useState<ReaderId | null>(null);
   const [isReaderSelectOpen, setIsReaderSelectOpen] = useState(false);
+  const [isDeckSelectOpen, setIsDeckSelectOpen] = useState(false);
+  const [isLanguageOpen, setIsLanguageOpen] = useState(false);
+  const [langSelection, setLangSelection] = useState<string>(locale);
   const [localeSaving, setLocaleSaving] = useState<string | null>(null);
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -259,6 +270,20 @@ export const UserProfile = () => {
     }
   };
 
+  const handleOpenLanguage = () => {
+    setLangSelection(locale);
+    setIsLanguageOpen(true);
+  };
+
+  const handleSaveLanguage = async () => {
+    if (langSelection === locale) {
+      setIsLanguageOpen(false);
+      return;
+    }
+    await handleSelectLocale(langSelection);
+    setIsLanguageOpen(false);
+  };
+
   const handleSelectLocale = async (loc: string) => {
     if (loc === locale || localeSaving) return;
     setLocaleSaving(loc);
@@ -303,7 +328,7 @@ export const UserProfile = () => {
 
   return (
     <div className="user-profile">
-      <div className="user-profile__field">
+      <div className={`user-profile__field${isEditingName ? "" : " user-profile__field--row"}`}>
         <span className="user-profile__label">{t("name")}</span>
         {isEditingName ? (
           <div className="user-profile__edit">
@@ -339,88 +364,117 @@ export const UserProfile = () => {
             {error && <span className="user-profile__error">{error}</span>}
           </div>
         ) : (
-          <span className="user-profile__value user-profile__value--editable" onClick={handleEditName}>
-            {session?.user?.name || t("mysticOne")}
+          <span className="user-profile__value-group">
+            <span className="user-profile__value">
+              {session?.user?.name || t("mysticOne")}
+            </span>
+            <button
+              type="button"
+              className="user-profile__edit-icon"
+              onClick={handleEditName}
+              aria-label={t("name")}
+            >
+              <EditIcon />
+            </button>
           </span>
         )}
       </div>
-      <div className="user-profile__field">
+      <div className="user-profile__field user-profile__field--row">
         <span className="user-profile__label">{t("email")}</span>
-        <span className="user-profile__value">{session?.user?.email}</span>
-      </div>
-      <div className="user-profile__field">
-        <span className="user-profile__label">{t("currentPlan")}</span>
-        <span className="user-profile__value">
-          {planId ? tPlans(`${planId}.name`) : "—"}
-          <Link href="/subscription" className="user-profile__upgrade">
-            {"→ " + t("initiation")}
-          </Link>
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">{session?.user?.email}</span>
         </span>
       </div>
-      <div className="user-profile__field">
+      <div className="user-profile__field user-profile__field--row">
+        <span className="user-profile__label">{t("currentPlan")}</span>
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">
+            {planId ? tPlans(`${planId}.name`) : "—"}
+          </span>
+          <button
+            type="button"
+            className="user-profile__edit-icon"
+            onClick={() => router.push("/subscription")}
+            aria-label={t("currentPlan")}
+          >
+            <EditIcon />
+          </button>
+        </span>
+      </div>
+      <div className="user-profile__field user-profile__field--row">
         <span className="user-profile__label">{t("credits")}</span>
-        <span className="user-profile__value">{credits}</span>
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">{credits}</span>
+        </span>
       </div>
       {(planId === "MONTHLY" || planId === "YEARLY") && (
-        <div className="user-profile__field">
+        <div className="user-profile__field user-profile__field--row">
           <span className="user-profile__label">{t("renewal")}</span>
-          <span className="user-profile__value">
-            {expiresAt
-              ? (autoRenew ? t("renewsOn", { date: expiresAt.slice(0, 10) })
-                           : t("accessUntil", { date: expiresAt.slice(0, 10) }))
-              : "—"}
+          <span className="user-profile__value-group">
+            <span className="user-profile__value">
+              {expiresAt ? formatDate(expiresAt) : "—"}
+            </span>
             <button
               type="button"
-              className="user-profile__upgrade"
+              className="user-profile__edit-icon"
               onClick={handleToggleAutoRenew}
               disabled={subSaving}
+              aria-label={autoRenew ? t("cancelSubscription") : t("resumeSubscription")}
             >
-              {"→ " + (autoRenew ? t("cancelSubscription") : t("resumeSubscription"))}
+              <EditIcon />
             </button>
           </span>
         </div>
       )}
-      <div className="user-profile__field">
+      <div className="user-profile__field user-profile__field--row">
         <span className="user-profile__label">{t("deck")}</span>
-        <span className="user-profile__value">
-          {deckId === "Rider-Waite" ? t("deckRiderWaite") :
-           deckId === "Klimt" ? t("deckKlimt") :
-           deckId === "Gothic-Vintage" ? t("deckGothicVintage") : "—"}
-          <Link href="/decks" className="user-profile__upgrade">
-            {"→ " + t("chooseDeck")}
-          </Link>
-        </span>
-      </div>
-      <div className="user-profile__field">
-        <span className="user-profile__label">{t("reader")}</span>
-        <span className="user-profile__value">
-          {readerId ? tReaders(`${readerId}.displayName`) : "—"}
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">
+            {deckId === "Rider-Waite" ? t("deckRiderWaite") :
+             deckId === "Klimt" ? t("deckKlimt") :
+             deckId === "Gothic-Vintage" ? t("deckGothicVintage") : "—"}
+          </span>
           <button
             type="button"
-            className="user-profile__upgrade"
-            onClick={() => setIsReaderSelectOpen(true)}
+            className="user-profile__edit-icon"
+            onClick={() => setIsDeckSelectOpen(true)}
+            aria-label={t("chooseDeck")}
           >
-            {"→ " + t("chooseReader")}
+            <EditIcon />
           </button>
         </span>
       </div>
-      <div className="user-profile__field">
-        <span className="user-profile__label">{t("language")}</span>
-        <div className="user-profile__language-options">
-          {routing.locales.map((loc) => (
-            <button
-              key={loc}
-              type="button"
-              className={`user-profile__language-option${loc === locale ? " user-profile__language-option--active" : ""}`}
-              onClick={() => handleSelectLocale(loc)}
-              disabled={localeSaving !== null}
-            >
-              {LOCALE_NAMES[loc]}
-            </button>
-          ))}
-        </div>
+      <div className="user-profile__field user-profile__field--row">
+        <span className="user-profile__label">{t("reader")}</span>
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">
+            {readerId ? tReaders(`${readerId}.displayName`) : "—"}
+          </span>
+          <button
+            type="button"
+            className="user-profile__edit-icon"
+            onClick={() => setIsReaderSelectOpen(true)}
+            aria-label={t("chooseReader")}
+          >
+            <EditIcon />
+          </button>
+        </span>
       </div>
-      <div className="user-profile__field">
+      <div className="user-profile__field user-profile__field--row">
+        <span className="user-profile__label">{t("language")}</span>
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">{LOCALE_NAMES[locale]}</span>
+          <button
+            type="button"
+            className="user-profile__edit-icon"
+            onClick={handleOpenLanguage}
+            aria-label={t("language")}
+          >
+            <EditIcon />
+          </button>
+        </span>
+      </div>
+      <div className={`user-profile__field${isEditingPassword ? "" : " user-profile__field--row"}`}>
         <span className="user-profile__label">{t("password")}</span>
         {isEditingPassword ? (
           <div className="user-profile__edit">
@@ -475,8 +529,18 @@ export const UserProfile = () => {
             {passwordSuccess && <span className="user-profile__success">{passwordSuccess}</span>}
           </div>
         ) : (
-          <span className="user-profile__value user-profile__value--editable" onClick={handleEditPassword}>
-            {hasPassword ? t("changePassword") : t("setPassword")}
+          <span className="user-profile__value-group">
+            <span className="user-profile__value">
+              {hasPassword ? t("changePassword") : t("setPassword")}
+            </span>
+            <button
+              type="button"
+              className="user-profile__edit-icon"
+              onClick={handleEditPassword}
+              aria-label={t("password")}
+            >
+              <EditIcon />
+            </button>
           </span>
         )}
       </div>
@@ -503,6 +567,48 @@ export const UserProfile = () => {
         onClose={() => setIsReaderSelectOpen(false)}
         onOpenSubscription={() => router.push("/subscription")}
       />
+      <Modal
+        isOpen={isDeckSelectOpen}
+        onClose={() => setIsDeckSelectOpen(false)}
+        title={t("chooseDeck")}
+        wide
+      >
+        <DeckSelector inModal />
+      </Modal>
+      <Modal
+        isOpen={isLanguageOpen}
+        onClose={() => setIsLanguageOpen(false)}
+        title={t("language")}
+      >
+        <div className="options-modal">
+          <ul className="options-modal__list list">
+            {routing.locales.map((loc) => (
+              <li key={loc} className="options-modal__item">
+                <label className="options-modal__option">
+                  <input
+                    type="radio"
+                    name="profile-language"
+                    className="options-modal__radio-input"
+                    checked={langSelection === loc}
+                    onChange={() => setLangSelection(loc)}
+                    disabled={localeSaving !== null}
+                  />
+                  <span className="options-modal__radio" aria-hidden="true" />
+                  <span className="options-modal__option-label">{LOCALE_NAMES[loc]}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="options-modal__save"
+            onClick={handleSaveLanguage}
+            disabled={localeSaving !== null}
+          >
+            {localeSaving ? t("saving") : t("save")}
+          </button>
+        </div>
+      </Modal>
       <Modal
         isOpen={isDeleteModalOpen}
         onClose={handleCloseDeleteModal}


### PR DESCRIPTION
  - deck / reader / language / renewal / name / plan / password now render as label–value rows with an edit-icon button
  - deck icon opens deck picker modal (DeckSelector gains `inModal` prop); language icon opens new radio-list options modal; reader/name/password/plan reuse existing actions
  - renewal: date-only dd/mm/yy value; translate `renewal` label for no/uk/tr
  - add edit.svg icon; drop dead __upgrade/--editable styles and unused Link import