### PR TITLE
feat(profile): subscription & account edits as modals; fix plan/reade…

### DIFF
--- a/src/app/[locale]/HomePageClient.tsx
+++ b/src/app/[locale]/HomePageClient.tsx
@@ -6,11 +6,10 @@ import { OfferBlock } from "@/components/OfferBlock";
 import { Tarot } from "@/components/Tarot";
 import { Modal } from "@/components/Modal";
 import { LoginForm } from "@/components/LoginForm";
-import { SubscriptionPlans } from "@/components/SubscriptionPlans";
+import { SubscriptionModal } from "@/components/SubscriptionModal";
 import { Header } from "@/components/Header";
 import Footer from "@/components/Footer";
 import { Providers } from "@/components/Providers";
-import { LoginContext } from "@/components/LoginContext";
 
 export function HomePageClient() {
   const t = useTranslations("ui");
@@ -38,21 +37,11 @@ export function HomePageClient() {
       >
         <LoginForm onSuccess={() => setIsLoginOpen(false)} />
       </Modal>
-      <Modal
-        title={t("chooseYourPath")}
+      <SubscriptionModal
         isOpen={isSubscriptionOpen}
         onClose={() => setIsSubscriptionOpen(false)}
-        wide
-      >
-        <LoginContext.Provider
-          value={() => {
-            setIsSubscriptionOpen(false);
-            setIsLoginOpen(true);
-          }}
-        >
-          <SubscriptionPlans showHeader={false} />
-        </LoginContext.Provider>
-      </Modal>
+        onRequestLogin={() => setIsLoginOpen(true)}
+      />
     </Providers>
   );
 }

--- a/src/assets/scss/blocks/_form.scss
+++ b/src/assets/scss/blocks/_form.scss
@@ -60,6 +60,12 @@
   text-align: center;
 }
 
+.form__success {
+  color: var(--success);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
 .form__btn--google {
   background-color: transparent;
   border: var(--border);

--- a/src/assets/scss/blocks/_user-profile.scss
+++ b/src/assets/scss/blocks/_user-profile.scss
@@ -102,77 +102,9 @@
     color: var(--primary);
   }
 
-  .user-profile__edit {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-
-  .user-profile__input {
-    padding: 0.3rem 0.75rem;
-    height: 40px;
-    font-size: 1.1rem;
-    font-weight: 200;
-    font-family: var(--font-family);
-    color: var(--text-color);
-    background-color: var(--input-bg);
-    border: var(--border);
-    border-radius: var(--border-radius);
-    width: 100%;
-
-    &:focus {
-      border: var(--border);
-      outline: none;
-    }
-  }
-
-  .user-profile__edit-actions {
-    display: flex;
-    gap: 0.5rem;
-  }
-
-  .user-profile__edit-btn {
-    padding: 0.35rem 0.75rem;
-    font-size: 0.85rem;
-    font-family: var(--font-family);
-    border-radius: var(--border-radius);
-    border: var(--border);
-    cursor: pointer;
-    transition: opacity 0.2s;
-
-    &:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    &--save {
-      background-color: rgba(250, 225, 163, 0.15);
-      color: var(--primary);
-
-      &:hover:not(:disabled) {
-        background-color: rgba(250, 225, 163, 0.25);
-      }
-    }
-
-    &--cancel {
-      background-color: transparent;
-      color: var(--text-faint);
-
-      &:hover:not(:disabled) {
-        color: var(--text-color);
-      }
-    }
-  }
-
-  .user-profile__error {
-    color: var(--error);
-    font-size: 0.85rem;
-  }
-
-  .user-profile__success {
-    color: var(--success);
-    font-size: 0.85rem;
-  }
+  // Name / Password editors now reuse the shared .form controls (matching the
+  // auth modal) inside a portaled Modal — the bespoke .user-profile__edit /
+  // __input / __edit-btn / __error / __success rules that lived here are gone.
 
   .user-profile__btn {
     margin-top: 1rem;

--- a/src/components/SubscriptionModal.tsx
+++ b/src/components/SubscriptionModal.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Modal } from "@/components/Modal";
+import { SubscriptionPlans } from "@/components/SubscriptionPlans";
+import { LoginContext, useOpenLogin } from "@/components/LoginContext";
+
+type SubscriptionModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  /**
+   * Called (after this modal closes) when the plans need the user to sign in —
+   * a 401 from create-invoice. Defaults to the ambient LoginContext, which is
+   * correct anywhere a login modal already sits above this (e.g. PageShell).
+   * The home page has no such ambient provider, so it passes this explicitly.
+   */
+  onRequestLogin?: () => void;
+};
+
+/**
+ * The pricing plans in a modal — same content as the /subscription page.
+ * Reused by the home page (reading-gate upgrade prompt) and the profile
+ * (current-plan / reader-upgrade). Overrides LoginContext so a 401 closes the
+ * plans and hands off to login instead of failing.
+ */
+export const SubscriptionModal = ({
+  isOpen,
+  onClose,
+  onRequestLogin,
+}: SubscriptionModalProps) => {
+  const t = useTranslations("ui");
+  const ambientOpenLogin = useOpenLogin();
+
+  const handleLogin = () => {
+    onClose();
+    (onRequestLogin ?? ambientOpenLogin)();
+  };
+
+  return (
+    <Modal title={t("chooseYourPath")} isOpen={isOpen} onClose={onClose} wide>
+      <LoginContext.Provider value={handleLogin}>
+        <SubscriptionPlans showHeader={false} />
+      </LoginContext.Provider>
+    </Modal>
+  );
+};

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -8,6 +8,7 @@ import { routing } from "@/i18n/routing";
 import { type PlanId } from "@/lib/plans";
 import { type ReaderId } from "@/lib/readers";
 import { ReaderSelectionModal } from "@/components/ReaderSelectionModal";
+import { SubscriptionModal } from "@/components/SubscriptionModal";
 import { DeckSelector } from "@/components/DeckSelector";
 import { Modal } from "@/components/Modal";
 import EditIcon from "@/assets/svg/edit.svg";
@@ -51,6 +52,7 @@ export const UserProfile = () => {
   const [deckId, setDeckId] = useState<string | null>(null);
   const [readerId, setReaderId] = useState<ReaderId | null>(null);
   const [isReaderSelectOpen, setIsReaderSelectOpen] = useState(false);
+  const [isSubscriptionOpen, setIsSubscriptionOpen] = useState(false);
   const [isDeckSelectOpen, setIsDeckSelectOpen] = useState(false);
   const [isLanguageOpen, setIsLanguageOpen] = useState(false);
   const [langSelection, setLangSelection] = useState<string>(locale);
@@ -328,56 +330,21 @@ export const UserProfile = () => {
 
   return (
     <div className="user-profile">
-      <div className={`user-profile__field${isEditingName ? "" : " user-profile__field--row"}`}>
+      <div className="user-profile__field user-profile__field--row">
         <span className="user-profile__label">{t("name")}</span>
-        {isEditingName ? (
-          <div className="user-profile__edit">
-            <input
-              className="user-profile__input"
-              type="text"
-              value={nameInput}
-              onChange={(e) => setNameInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleSaveName();
-                if (e.key === "Escape") handleCancelEdit();
-              }}
-              maxLength={100}
-              autoFocus
-              disabled={isSaving}
-            />
-            <div className="user-profile__edit-actions">
-              <button
-                className="user-profile__edit-btn user-profile__edit-btn--save"
-                onClick={handleSaveName}
-                disabled={isSaving}
-              >
-                {isSaving ? t("saving") : t("save")}
-              </button>
-              <button
-                className="user-profile__edit-btn user-profile__edit-btn--cancel"
-                onClick={handleCancelEdit}
-                disabled={isSaving}
-              >
-                {t("cancel")}
-              </button>
-            </div>
-            {error && <span className="user-profile__error">{error}</span>}
-          </div>
-        ) : (
-          <span className="user-profile__value-group">
-            <span className="user-profile__value">
-              {session?.user?.name || t("mysticOne")}
-            </span>
-            <button
-              type="button"
-              className="user-profile__edit-icon"
-              onClick={handleEditName}
-              aria-label={t("name")}
-            >
-              <EditIcon />
-            </button>
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">
+            {session?.user?.name || t("mysticOne")}
           </span>
-        )}
+          <button
+            type="button"
+            className="user-profile__edit-icon"
+            onClick={handleEditName}
+            aria-label={t("name")}
+          >
+            <EditIcon />
+          </button>
+        </span>
       </div>
       <div className="user-profile__field user-profile__field--row">
         <span className="user-profile__label">{t("email")}</span>
@@ -394,7 +361,7 @@ export const UserProfile = () => {
           <button
             type="button"
             className="user-profile__edit-icon"
-            onClick={() => router.push("/subscription")}
+            onClick={() => setIsSubscriptionOpen(true)}
             aria-label={t("currentPlan")}
           >
             <EditIcon />
@@ -474,75 +441,21 @@ export const UserProfile = () => {
           </button>
         </span>
       </div>
-      <div className={`user-profile__field${isEditingPassword ? "" : " user-profile__field--row"}`}>
+      <div className="user-profile__field user-profile__field--row">
         <span className="user-profile__label">{t("password")}</span>
-        {isEditingPassword ? (
-          <div className="user-profile__edit">
-            {hasPassword && (
-              <input
-                className="user-profile__input"
-                type="password"
-                placeholder={t("currentPasswordPlaceholder")}
-                value={currentPassword}
-                onChange={(e) => setCurrentPassword(e.target.value)}
-                disabled={passwordSaving}
-              />
-            )}
-            <input
-              className="user-profile__input"
-              type="password"
-              placeholder={t("newPasswordPlaceholder")}
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              disabled={passwordSaving}
-              autoFocus
-            />
-            <input
-              className="user-profile__input"
-              type="password"
-              placeholder={t("confirmPasswordPlaceholder")}
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") handleSavePassword();
-                if (e.key === "Escape") handleCancelPassword();
-              }}
-              disabled={passwordSaving}
-            />
-            <div className="user-profile__edit-actions">
-              <button
-                className="user-profile__edit-btn user-profile__edit-btn--save"
-                onClick={handleSavePassword}
-                disabled={passwordSaving}
-              >
-                {passwordSaving ? t("saving") : t("save")}
-              </button>
-              <button
-                className="user-profile__edit-btn user-profile__edit-btn--cancel"
-                onClick={handleCancelPassword}
-                disabled={passwordSaving}
-              >
-                {t("cancel")}
-              </button>
-            </div>
-            {passwordError && <span className="user-profile__error">{passwordError}</span>}
-            {passwordSuccess && <span className="user-profile__success">{passwordSuccess}</span>}
-          </div>
-        ) : (
-          <span className="user-profile__value-group">
-            <span className="user-profile__value">
-              {hasPassword ? t("changePassword") : t("setPassword")}
-            </span>
-            <button
-              type="button"
-              className="user-profile__edit-icon"
-              onClick={handleEditPassword}
-              aria-label={t("password")}
-            >
-              <EditIcon />
-            </button>
+        <span className="user-profile__value-group">
+          <span className="user-profile__value">
+            {hasPassword ? t("changePassword") : t("setPassword")}
           </span>
-        )}
+          <button
+            type="button"
+            className="user-profile__edit-icon"
+            onClick={handleEditPassword}
+            aria-label={t("password")}
+          >
+            <EditIcon />
+          </button>
+        </span>
       </div>
       <button
         className="btn user-profile__btn"
@@ -565,8 +478,131 @@ export const UserProfile = () => {
       <ReaderSelectionModal
         isOpen={isReaderSelectOpen}
         onClose={() => setIsReaderSelectOpen(false)}
-        onOpenSubscription={() => router.push("/subscription")}
+        onOpenSubscription={() => setIsSubscriptionOpen(true)}
       />
+      <SubscriptionModal
+        isOpen={isSubscriptionOpen}
+        onClose={() => setIsSubscriptionOpen(false)}
+      />
+      <Modal
+        isOpen={isEditingName}
+        onClose={handleCancelEdit}
+        title={t("name")}
+      >
+        <form
+          className="form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSaveName();
+          }}
+        >
+          <div className="form__input-block">
+            <label htmlFor="profile-name" className="form__label">
+              {t("whatShallWeCallYou")}
+            </label>
+            <input
+              id="profile-name"
+              className="form__input"
+              type="text"
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+              maxLength={100}
+              autoFocus
+              disabled={isSaving}
+            />
+          </div>
+          {error && <div className="form__error">{error}</div>}
+          <div className="form__input-block">
+            <button type="submit" className="btn form__btn" disabled={isSaving}>
+              {isSaving ? t("saving") : t("save")}
+            </button>
+            <button
+              type="button"
+              className="btn form__btn form__btn--google"
+              onClick={handleCancelEdit}
+              disabled={isSaving}
+            >
+              {t("cancel")}
+            </button>
+          </div>
+        </form>
+      </Modal>
+      <Modal
+        isOpen={isEditingPassword}
+        onClose={handleCancelPassword}
+        title={hasPassword ? t("changePassword") : t("setPassword")}
+      >
+        <form
+          className="form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSavePassword();
+          }}
+        >
+          {hasPassword && (
+            <div className="form__input-block">
+              <label htmlFor="current-password" className="form__label">
+                {t("currentPasswordPlaceholder")}
+              </label>
+              <input
+                id="current-password"
+                className="form__input"
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                disabled={passwordSaving}
+              />
+            </div>
+          )}
+          <div className="form__input-block">
+            <label htmlFor="new-password" className="form__label">
+              {t("newPasswordPlaceholder")}
+            </label>
+            <input
+              id="new-password"
+              className="form__input"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              minLength={8}
+              autoFocus
+              disabled={passwordSaving}
+            />
+          </div>
+          <div className="form__input-block">
+            <label htmlFor="confirm-password" className="form__label">
+              {t("confirmPasswordPlaceholder")}
+            </label>
+            <input
+              id="confirm-password"
+              className="form__input"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              disabled={passwordSaving}
+            />
+          </div>
+          {passwordError && <div className="form__error">{passwordError}</div>}
+          {passwordSuccess && <div className="form__success">{passwordSuccess}</div>}
+          <div className="form__input-block">
+            <button
+              type="submit"
+              className="btn form__btn"
+              disabled={passwordSaving}
+            >
+              {passwordSaving ? t("saving") : t("save")}
+            </button>
+            <button
+              type="button"
+              className="btn form__btn form__btn--google"
+              onClick={handleCancelPassword}
+              disabled={passwordSaving}
+            >
+              {t("cancel")}
+            </button>
+          </div>
+        </form>
+      </Modal>
       <Modal
         isOpen={isDeckSelectOpen}
         onClose={() => setIsDeckSelectOpen(false)}


### PR DESCRIPTION
…r indicators

  - Pricing now reflects the real plan: SubscriptionPlans fetches GET /api/user/plan and marks the matching tier "Current plan" instead of hardcoding Free as active. Free shows "Included" when on a paid tier; SINGLE stays purchasable. Adds ui.includedBtn across en/no/ru/uk/tr.
  - Reusable SubscriptionModal (pricing plans in a modal, with the 401→login handoff). Wired into the profile (Current plan + reader "upgrade to unlock") so they open the modal instead of routing to /subscription; home page reuses it too. The /subscription page is kept (SEO canonical + legal-page links).
  - Reader modal: decouple the two corner markers that collided on a single ::after — the paid-tier ★ is now a real element; the current-reader marker is a shiny gold bead (gradient + subtle glow) seated on the top border, 20px from the left. Card no longer clips it (overflow removed; aura tint keeps border-radius: inherit).
  - Name and Password editing moved from inline fields to small modals that match the auth modal (.form structure, 50px inputs, labels, full-width Save/Cancel). Adds .form__success; removes the now-dead .user-profile__edit* styles.