### PR TITLE
 feat(header): open language picker in a modal; add pricing link to p…

### DIFF
--- a/src/assets/scss/blocks/_language-switcher.scss
+++ b/src/assets/scss/blocks/_language-switcher.scss
@@ -1,10 +1,7 @@
 .language-switcher {
-  position: relative;
-
   &__trigger {
     display: flex;
     align-items: center;
-    gap: 4px;
     background: transparent;
     border: none;
     cursor: pointer;
@@ -15,53 +12,6 @@
       width: 20px;
       height: 20px;
       stroke: var(--primary);
-
-      &:last-child {
-        width: 14px;
-        height: 14px;
-      }
-    }
-  }
-
-  &__dropdown {
-    position: absolute;
-    top: 100%;
-    right: 0;
-    margin-top: 8px;
-    padding: 4px 0;
-    list-style: none;
-    background: var(--bg);
-    border: var(--border);
-    border-radius: var(--border-radius);
-    min-width: 120px;
-    z-index: 200;
-  }
-
-  &__option {
-    display: block;
-    width: 100%;
-    padding: 8px 16px;
-    background: transparent;
-    border: none;
-    color: var(--primary);
-    font-family: var(--font-family);
-    font-size: 0.85rem;
-    font-weight: var(--font-weight);
-    text-align: left;
-    cursor: pointer;
-    white-space: nowrap;
-
-    &:hover {
-      background: rgba(250, 225, 163, 0.1);
-    }
-
-    &--active {
-      color: var(--text-faint);
-      cursor: default;
-
-      &:hover {
-        background: transparent;
-      }
     }
   }
 }

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
-import { useLocale } from "next-intl";
+import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import { useSession } from "next-auth/react";
 import { useRouter, usePathname } from "@/i18n/navigation";
 import { routing } from "@/i18n/routing";
+import { Modal } from "@/components/Modal";
 import GlobeIcon from "@/assets/svg/globe.svg";
-import ChevronDown from "@/assets/svg/chevron-down.svg";
 
 const localeNames: Record<string, string> = {
   en: "English",
@@ -18,66 +18,88 @@ const localeNames: Record<string, string> = {
 
 export const LanguageSwitcher = () => {
   const locale = useLocale();
+  const t = useTranslations("ui");
   const router = useRouter();
   const pathname = usePathname();
   const { data: session, update: updateSession } = useSession();
   const [isOpen, setIsOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const [selected, setSelected] = useState(locale);
+  const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
+  const handleOpen = () => {
+    setSelected(locale);
+    setIsOpen(true);
+  };
 
-  const handleSelect = async (loc: string) => {
-    setIsOpen(false);
-    router.replace(pathname, { locale: loc });
+  const handleSave = async () => {
+    if (saving) return;
+    if (selected === locale) {
+      setIsOpen(false);
+      return;
+    }
+    setSaving(true);
 
+    // Persist the preference for signed-in users (best-effort); the URL change
+    // below takes effect regardless.
     if (session?.user?.id) {
       try {
         const res = await fetch("/api/user/locale", {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ locale: loc }),
+          body: JSON.stringify({ locale: selected }),
         });
         if (res.ok) {
-          await updateSession({ preferredLocale: loc });
+          await updateSession({ preferredLocale: selected });
         }
       } catch {
         // Non-critical — URL change still takes effect for this session.
       }
     }
+
+    router.replace(pathname, { locale: selected });
+    setSaving(false);
+    setIsOpen(false);
   };
 
   return (
-    <div className="language-switcher" ref={ref}>
+    <div className="language-switcher">
       <button
         className="language-switcher__trigger"
-        onClick={() => setIsOpen(!isOpen)}
-        aria-label="Language"
+        onClick={handleOpen}
+        aria-label={t("language")}
       >
         <GlobeIcon />
-        <ChevronDown />
       </button>
-      {isOpen && (
-        <ul className="language-switcher__dropdown">
-          {routing.locales.map((loc) => (
-            <li key={loc}>
-              <button
-                className={`language-switcher__option${loc === locale ? " language-switcher__option--active" : ""}`}
-                onClick={() => handleSelect(loc)}
-              >
-                {localeNames[loc]}
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)} title={t("language")}>
+        <div className="options-modal">
+          <ul className="options-modal__list list">
+            {routing.locales.map((loc) => (
+              <li key={loc} className="options-modal__item">
+                <label className="options-modal__option">
+                  <input
+                    type="radio"
+                    name="header-language"
+                    className="options-modal__radio-input"
+                    checked={selected === loc}
+                    onChange={() => setSelected(loc)}
+                    disabled={saving}
+                  />
+                  <span className="options-modal__radio" aria-hidden="true" />
+                  <span className="options-modal__option-label">{localeNames[loc]}</span>
+                </label>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="options-modal__save"
+            onClick={handleSave}
+            disabled={saving}
+          >
+            {saving ? t("saving") : t("save")}
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -372,6 +372,14 @@ export const UserProfile = () => {
         <span className="user-profile__label">{t("credits")}</span>
         <span className="user-profile__value-group">
           <span className="user-profile__value">{credits}</span>
+          <button
+            type="button"
+            className="user-profile__edit-icon"
+            onClick={() => setIsSubscriptionOpen(true)}
+            aria-label={t("credits")}
+          >
+            <EditIcon />
+          </button>
         </span>
       </div>
       {(planId === "MONTHLY" || planId === "YEARLY") && (


### PR DESCRIPTION
…rofile credits

  - LanguageSwitcher: drop the chevron and dropdown; the globe now opens the same radio-list modal used in the profile (commit-on-Save, persists via /api/user/locale for signed-in users). Removes the click-outside handler and the now-dead dropdown styles.
  - Profile: add an edit-icon to the Reading Credits row that opens the subscription/pricing modal.