### PR TITLE
feat(i18n): localize the /payment/result page

### DIFF
--- a/src/app/api/payments/create-invoice/route.ts
+++ b/src/app/api/payments/create-invoice/route.ts
@@ -38,11 +38,17 @@ export async function POST(request: Request) {
   }
   const plan = planId as PaidPlanId;
 
-  // Route Mono's post-payment redirect to the localized result page. Fall back
-  // to the default locale if the client sent nothing / something unrecognized.
-  const resultLocale =
-    typeof locale === "string" && routing.locales.includes(locale as any)
-      ? locale
+  // Route Mono's post-payment redirect to the localized result page. Prefer the
+  // locale the client is currently viewing; if it's missing/unrecognized (e.g. a
+  // stale bundle), fall back to the user's saved account language — payments are
+  // always logged-in, so a Russian account never lands on an English page — and
+  // only then to the default locale.
+  const isLocale = (v: unknown): v is string =>
+    typeof v === "string" && routing.locales.includes(v as any);
+  const resultLocale = isLocale(locale)
+    ? locale
+    : isLocale(session.user.preferredLocale)
+      ? session.user.preferredLocale
       : routing.defaultLocale;
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL;


### PR DESCRIPTION
  The post-payment result page was English-only because Mono's redirect
  carries no locale. create-invoice now builds redirectUrl =
  ${APP_URL}/${locale}/payment/result: it prefers the locale the client is
  viewing, falls back to the user's saved account language (payments are
  always logged-in, so a non-English account never lands on English), then
  the default locale.
  - New localized page at [locale]/payment/result/ + `payment` namespace in all 5 locales (messages/*/payment.json, registered in request.ts).
  - Middleware no longer strips the locale off /{locale}/payment/result.
  - Unprefixed /payment/result kept as a fallback that redirects to the default locale (covers pre-change invoices); old component removed.

  Docs: mark payment-result localization done, and record the credit + tier
  loop verified live on prod (2026-07-13) — last blocking launch item cleared.